### PR TITLE
application-security.yml 수정 및 푸시알림 엔티티 필드 에러 해결

### DIFF
--- a/src/main/java/com/petmeet/api/core/domain/pushnotification/PushNotificationEntity.java
+++ b/src/main/java/com/petmeet/api/core/domain/pushnotification/PushNotificationEntity.java
@@ -28,7 +28,7 @@ public class PushNotificationEntity extends BaseTimeEntity {
 
     private String content;
 
-    private boolean read;
+    private boolean isRead;
 
     @Enumerated(EnumType.STRING)
     private Status status;

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -13,10 +13,10 @@ spring:
             client_secret: ENC(YfME8cD6lmPqt9NA0eEaZr5pV1Qg7y700yFfzvSDuEestQ7Hp2TDwh9J2rtW+fgw)
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: ${MY_APP_URL:http://localhost:8080}/login/oauth2/code/kakao
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
             client-name: Kakao
             provider: kakao
-          apple:
+          #apple:
 
         provider:
           kakao:
@@ -25,7 +25,7 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-info-authentication-method: header
             user-name-attribute: id
-          apple:
+          #apple:
 
 
 # Jasypt


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요. -->
<!--
ex) close #1
-->
- close #8 
</br>
</br>

## 📂 작업 분류 <!-- 한개 이상 체크해주세요. -->
- [ ] 기능 추가
- [X] 기능 및 버그 수정
- [ ] 기능 업데이트
- [ ] 기능 삭제
- [ ] 문서 작업
- [ ] 설정 및 셋팅
- [ ] 기타
</br>
</br>

## 🔎 작업 내용(변경 사항) <!-- 자세히 작성해주세요. -->
<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->
- 일관된 URL 처리를 위해 application-security.yml 카카오 redirect-uri 세팅 정보에 {baseUrl}/ 경로를 추가하고 "" 문자열로 묶어 처리
Commit: 9683e695d89171f0e7431bc8778833ca4f3c8a4a
- 기존 푸시알림 엔티티에서 read 필드가 MySQL에서 예약어로 설정되어 있어 isRead로 필드명을 수정해 에러 해결
Commit: a5e44224bb7544510f33c9fec6015709c8a9f144
</br>
</br>

## 🚀 기타
- 
</br>
</br>
