### PR TITLE
공통 응답 클래스 구현

### DIFF
--- a/src/main/java/com/petmeet/api/api/controller/dto/response/BaseApiResponse.java
+++ b/src/main/java/com/petmeet/api/api/controller/dto/response/BaseApiResponse.java
@@ -1,0 +1,35 @@
+package com.petmeet.api.api.controller.dto.response;
+
+import com.petmeet.api.core.enums.SuccessResponseType;
+import com.petmeet.api.core.exception.errorcode.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BaseApiResponse<D> {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final D data;
+
+    private BaseApiResponse(HttpStatus httpStatus, String message, D data) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+        this.data = data;
+    }
+
+    // 성공 응답 (응답 데이터가 있는 경우)
+    public static <D> BaseApiResponse<D> success(SuccessResponseType responseType, D data) {
+        return new BaseApiResponse<>(responseType.getHttpStatus(), responseType.getMessage(), data);
+    }
+
+    // 성공 응답 (응답 데이터가 없는 경우)
+    public static <D> BaseApiResponse<D> success(SuccessResponseType responseType) {
+        return new BaseApiResponse<>(responseType.getHttpStatus(), responseType.getMessage(), null);
+    }
+
+    // 실패, 에러 응답
+    public static <D> BaseApiResponse<D> error(BaseErrorCode errorCode) {
+        return new BaseApiResponse<>(errorCode.getHttpStatus(), errorCode.getMessage(), null);
+    }
+}

--- a/src/main/java/com/petmeet/api/api/controller/dto/response/BasePagingResponse.java
+++ b/src/main/java/com/petmeet/api/api/controller/dto/response/BasePagingResponse.java
@@ -1,0 +1,26 @@
+package com.petmeet.api.api.controller.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BasePagingResponse<D> {
+
+    private boolean isLast;
+    private List<D> content;
+    private int page;
+    private int size;
+
+    public static <D, T> BasePagingResponse<D> of(Page<T> page, List<D> content) {
+        return BasePagingResponse.<D>builder()
+                .isLast(page.isLast())
+                .content(content)
+                .page(page.getNumber())
+                .size(page.getSize())
+                .build();
+    }
+}

--- a/src/main/java/com/petmeet/api/core/enums/SuccessResponseType.java
+++ b/src/main/java/com/petmeet/api/core/enums/SuccessResponseType.java
@@ -1,0 +1,23 @@
+package com.petmeet.api.core.enums;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SuccessResponseType {
+
+    SUCCESS(HttpStatus.OK, "Request was successful"),
+    CREATED(HttpStatus.CREATED, "Resource was created successfully"),
+    UPDATED_WITH_CONTENT(HttpStatus.OK, "Resource was updated successfully"),
+    UPDATED(HttpStatus.NO_CONTENT, "Resource was updated successfully"),
+    DELETED_WITH_CONTENT(HttpStatus.OK, "Resource was deleted successfully"),
+    DELETED(HttpStatus.NO_CONTENT, "Resource was deleted successfully");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    SuccessResponseType(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/petmeet/api/core/exception/errorcode/BaseErrorCode.java
+++ b/src/main/java/com/petmeet/api/core/exception/errorcode/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package com.petmeet.api.core.exception.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요. -->
<!--
ex) close #1
-->
- close #13 
</br>
</br>

## 📂 작업 분류 <!-- 한개 이상 체크해주세요. -->
- [X] 기능 추가
- [ ] 기능 및 버그 수정
- [ ] 기능 업데이트
- [ ] 기능 삭제
- [ ] 문서 작업
- [ ] 설정 및 셋팅
- [ ] 기타
</br>
</br>

## 🔎 작업 내용(변경 사항) <!-- 자세히 작성해주세요. -->
<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->
- 일관된 성공 응답을 위한 SuccessResponseType enum 클래스 추가
(수정, 삭제 요청에 대한 상태 코드는 OK(본문 데이터 존재), NO_CONTENT(본문 데이터 X) 두 가지 경우로 설계)
Commit: 6f7b6732234002a3d6ff991f3ad6c411e2854ff4
- 실패, 에러 응답에 대한 에러코드를 관리하는 최상위 객체 BaseErrorCode 인터페이스 추가
Commit: 88c1bfebf8c00d51b4974e65913f5094e7820855
- 일관된 API 응답을 위한 BaseApiResponse 클래스 추가
(성공 응답 시 데이터가 있는 경우, 없는 경우 각각 분리)
Commit: 002f7f9d9540043207b1bb258e4b17063aceab2d
- 일관된 페이징 데이터 응답을 위한 BasePagingResponse 클래스 추가
Commit: f3b1ab1d83b4bc2cc8af64163ccf22ff9303ad8c
</br>
</br>

## 🚀 기타
- 일관된 페이징 데이터 응답을 위한 BasePagingResponse 클래스 추가로 등록했습니다. 
</br>
</br>
