### PR TITLE
BaseApiResponse 클래스에 직접 HttpStatus, 메시지를 전달하는 error 메소드 추가

### DIFF
--- a/src/main/java/com/petmeet/api/api/controller/dto/response/BaseApiResponse.java
+++ b/src/main/java/com/petmeet/api/api/controller/dto/response/BaseApiResponse.java
@@ -28,8 +28,13 @@ public class BaseApiResponse<D> {
         return new BaseApiResponse<>(responseType.getHttpStatus(), responseType.getMessage(), null);
     }
 
-    // 실패, 에러 응답
+    // 실패, 에러 응답 (커스텀 에러코드를 전달하는 경우)
     public static <D> BaseApiResponse<D> error(BaseErrorCode errorCode) {
         return new BaseApiResponse<>(errorCode.getHttpStatus(), errorCode.getMessage(), null);
+    }
+
+    // 실패, 에러 응답 (직접 HttpStatus, 메시지를 전달하는 경우)
+    public static <D> BaseApiResponse<D> error(HttpStatus httpStatus, String message) {
+        return new BaseApiResponse<>(httpStatus, message, null);
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호 <!-- 이슈 번호를 작성해주세요. -->
<!--
ex) close #1
-->
- close #17 
</br>
</br>

## 📂 작업 분류 <!-- 한개 이상 체크해주세요. -->
- [x] 기능 추가
- [ ] 기능 및 버그 수정
- [ ] 기능 업데이트
- [ ] 기능 삭제
- [ ] 문서 작업
- [ ] 설정 및 셋팅
- [ ] 기타
</br>
</br>

## 🔎 작업 내용(변경 사항) <!-- 자세히 작성해주세요. -->
<!--
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
-->
- BaseApiResponse 클래스에 커스텀 예외 이외에 자바 표준 예외를 유연하게 처리하기 위해 HttpStatus, 메시지를 직접 전달하는 error 메소드 추가
Commit: 973cbfa9cd8e84d7056a02802d2ff643d8985439
</br>
</br>

## 🚀 기타
- 
</br>
</br>
